### PR TITLE
Adding support for gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,2 @@
+FROM gitpod/workspace-full
+SHELL ["/bin/bash", "-c"]

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,30 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - name: node
+    init: npm install && npm run build
+    command: npm start
+
+# Set the following ports public
+ports:
+  - port: 3000
+
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: true
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: true
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: true


### PR DESCRIPTION
WIth the supplied changes, you can use the following link to open a browser with a running version of the application. This requires 0 setup by the user to be able to view/work on the project.  They will need to create a free gitpod.io account.

https://gitpod.io/#https://github.com/hedrickbt/gdwc-react-demo

You can also install a browser extension.  This will add a button when you are looking a the repo, on github, to open in GitPod.
https://www.gitpod.io/docs/browser-extension